### PR TITLE
Provide CMakeLists.txt files so the project can be build with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ dkms.conf
 
 # Build directories
 build/
+
+# Previus version of sdkconfig
+sdkconfig.old

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esp32_rf_receiver)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS ./esp32_rf_receiver.c
+                       INCLUDE_DIRS "include")
+


### PR DESCRIPTION
I like this application and the fact it has been prepared for esp-idf. My problem is it does not support CMake build system that has been introduced in esp-idf to replace GNU make build system. Fortunately CMake support may be easy added with this simple PR. 